### PR TITLE
Code Cleanup

### DIFF
--- a/HypnotoadPlugin/Configuration.cs
+++ b/HypnotoadPlugin/Configuration.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Dalamud.Configuration;
+﻿using Dalamud.Configuration;
 using Dalamud.Plugin;
 
 namespace HypnotoadPlugin;

--- a/HypnotoadPlugin/Configuration.cs
+++ b/HypnotoadPlugin/Configuration.cs
@@ -14,15 +14,15 @@ public class Configuration : IPluginConfiguration
     // the below exist just to make saving less cumbersome
 
     [NonSerialized]
-    private DalamudPluginInterface pluginInterface;
+    private DalamudPluginInterface _pluginInterface;
 
     public void Initialize(DalamudPluginInterface pluginInterface)
     {
-        this.pluginInterface = pluginInterface;
+        _pluginInterface = pluginInterface;
     }
 
     public void Save()
     {
-        pluginInterface!.SavePluginConfig(this);
+        _pluginInterface!.SavePluginConfig(this);
     }
 }

--- a/HypnotoadPlugin/Configuration.cs
+++ b/HypnotoadPlugin/Configuration.cs
@@ -8,14 +8,14 @@ public class Configuration : IPluginConfiguration
 {
     public int Version { get; set; } = 0;
 
-    public bool Autoconnect { get; set; } = true;
+    public bool AutoConnect { get; set; } = true;
 
     // the below exist just to make saving less cumbersome
 
     [NonSerialized]
-    private DalamudPluginInterface _pluginInterface;
+    private DalamudPluginInterface? _pluginInterface;
 
-    public void Initialize(DalamudPluginInterface pluginInterface)
+    public void Initialize(DalamudPluginInterface? pluginInterface)
     {
         _pluginInterface = pluginInterface;
     }

--- a/HypnotoadPlugin/HypnotoadPlugin.csproj
+++ b/HypnotoadPlugin/HypnotoadPlugin.csproj
@@ -7,7 +7,10 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
+  <PropertyGroup>
     <Description>BardMusicPlayer &amp; LightAmp companion for enhanced functionality.</Description>
     <PackageProjectUrl>https://github.com/BardMusicPlayer/Hypnotoad-Plugin</PackageProjectUrl>
     <Version>0.0.1.11</Version>

--- a/HypnotoadPlugin/HypnotoadPlugin.csproj
+++ b/HypnotoadPlugin/HypnotoadPlugin.csproj
@@ -10,7 +10,7 @@
 
     <Description>BardMusicPlayer &amp; LightAmp companion for enhanced functionality.</Description>
     <PackageProjectUrl>https://github.com/BardMusicPlayer/Hypnotoad-Plugin</PackageProjectUrl>
-    <Version>0.0.1.10</Version>
+    <Version>0.0.1.11</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/HypnotoadPlugin/HypnotoadPlugin.csproj
+++ b/HypnotoadPlugin/HypnotoadPlugin.csproj
@@ -8,6 +8,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/HypnotoadPlugin/MessageEnums.cs
+++ b/HypnotoadPlugin/MessageEnums.cs
@@ -25,24 +25,26 @@ public enum MessageType
 
 public readonly struct ChatMessageChannelType
 {
-    public static readonly ChatMessageChannelType None  = new("None",   0x0000, "");
-    public static readonly ChatMessageChannelType Say   = new("Say",    0x000A, "/s");
-    public static readonly ChatMessageChannelType Yell  = new("Yell",   0x001E, "/y");
-    public static readonly ChatMessageChannelType Shout = new("Shout",  0x000B, "/sh");
-    public static readonly ChatMessageChannelType Party = new("Party",  0x000E, "/p");
-    public static readonly ChatMessageChannelType FC    = new("FC",     0x0018, "/fc");
-    public static readonly IReadOnlyList<ChatMessageChannelType> All = new ReadOnlyCollection<ChatMessageChannelType>(new List<ChatMessageChannelType>
+    public static readonly  ChatMessageChannelType None        = new("None",         0x0000, "");
+    private static readonly ChatMessageChannelType Say         = new("Say",          0x000A, "/s");
+    private static readonly ChatMessageChannelType Yell        = new("Yell",         0x001E, "/y");
+    private static readonly ChatMessageChannelType Shout       = new("Shout",        0x000B, "/sh");
+    private static readonly ChatMessageChannelType Party       = new("Party",        0x000E, "/p");
+    private static readonly ChatMessageChannelType FreeCompany = new("Free Company", 0x0018, "/fc");
+
+    private static readonly IReadOnlyList<ChatMessageChannelType> All = new ReadOnlyCollection<ChatMessageChannelType>(new List<ChatMessageChannelType>
     {
         None,
         Say,
         Yell,
         Shout,
         Party,
-        FC
+        FreeCompany
     });
 
-    public string Name { get; }
-    public int ChannelCode { get; }
+    private string Name { get; }
+
+    private int ChannelCode { get; }
     public string ChannelShortCut { get; }
 
     private ChatMessageChannelType(string name, int channelCode, string channelShortCut)
@@ -54,11 +56,11 @@ public readonly struct ChatMessageChannelType
 
     public static ChatMessageChannelType ParseByChannelCode(int channelCode)
     {
-        TryParseByChannelCode(channelCode, out var result);
+        var _ = TryParseByChannelCode(channelCode, out var result);
         return result;
     }
 
-    public static bool TryParseByChannelCode(int channelCode, out ChatMessageChannelType result)
+    private static bool TryParseByChannelCode(int channelCode, out ChatMessageChannelType result)
     {
         if (All.Any(x => x.ChannelCode.Equals(channelCode)))
         {

--- a/HypnotoadPlugin/MessageEnums.cs
+++ b/HypnotoadPlugin/MessageEnums.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
+﻿using System.Collections.ObjectModel;
 
 namespace HypnotoadPlugin;
 

--- a/HypnotoadPlugin/MessageEnums.cs
+++ b/HypnotoadPlugin/MessageEnums.cs
@@ -22,7 +22,7 @@ public enum MessageType
 
     Chat = 40,
 
-    NetworkPacket = 50,
+    NetworkPacket = 50
 }
 
 public readonly struct ChatMessageChannelType

--- a/HypnotoadPlugin/Offsets/Chat.cs
+++ b/HypnotoadPlugin/Offsets/Chat.cs
@@ -39,22 +39,22 @@ public static partial class Chat
 {
     private delegate void ProcessChatBoxDelegate(nint uiModule, nint message, nint unused, byte a4);
 
-    private static ProcessChatBoxDelegate ProcessChatBox { get; }
+    private static ProcessChatBoxDelegate? ProcessChatBox { get; }
 
-    private static readonly unsafe delegate* unmanaged<Utf8String*, int, nint, void> _sanitiseString = null!;
+    private static readonly unsafe delegate* unmanaged<Utf8String*, int, nint, void> SanitizeString = null!;
 
     static Chat()
     {
-        if (Api.SigScanner.TryScanText(Signatures.SendChat, out var processChatBoxPtr))
+        if (Api.SigScanner != null && Api.SigScanner.TryScanText(Signatures.SendChat, out var processChatBoxPtr))
         {
             ProcessChatBox = Marshal.GetDelegateForFunctionPointer<ProcessChatBoxDelegate>(processChatBoxPtr);
         }
 
         unsafe
         {
-            if (Api.SigScanner.TryScanText(Signatures.SanitiseString, out var sanitisePtr))
+            if (Api.SigScanner != null && Api.SigScanner.TryScanText(Signatures.SanitiseString, out var sanitisePtr))
             {
-                _sanitiseString = (delegate* unmanaged<Utf8String*, int, nint, void>)sanitisePtr;
+                SanitizeString = (delegate* unmanaged<Utf8String*, int, nint, void>)sanitisePtr;
             }
         }
     }
@@ -72,7 +72,7 @@ public static partial class Chat
     /// </summary>
     /// <param name="message">Message to send</param>
     /// <exception cref="InvalidOperationException">If the signature for this function could not be found</exception>
-    public static unsafe void SendMessageUnsafe(byte[] message)
+    private static unsafe void SendMessageUnsafe(byte[] message)
     {
         if (ProcessChatBox == null)
         {
@@ -92,7 +92,7 @@ public static partial class Chat
 
     public static void SendMessage(string message)
     {
-        Api.Framework.RunOnTick(() => SendMessageInternal(message));
+        Api.Framework?.RunOnTick(() => SendMessageInternal(message));
     }
 
     /// <summary>
@@ -140,16 +140,16 @@ public static partial class Chat
     /// <param name="text">text to sanitise</param>
     /// <returns>sanitised text</returns>
     /// <exception cref="InvalidOperationException">If the signature for this function could not be found</exception>
-    public static unsafe string SanitiseText(string text)
+    private static unsafe string SanitiseText(string text)
     {
-        if (_sanitiseString == null)
+        if (SanitizeString == null)
         {
             throw new InvalidOperationException("Could not find signature for chat sanitization");
         }
 
         var uText = Utf8String.FromString(text);
 
-        _sanitiseString(uText, 0x27F, nint.Zero);
+        SanitizeString(uText, 0x27F, nint.Zero);
         var sanitised = uText->ToString();
 
         uText->Dtor();

--- a/HypnotoadPlugin/Offsets/Chat.cs
+++ b/HypnotoadPlugin/Offsets/Chat.cs
@@ -23,7 +23,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/HypnotoadPlugin/Offsets/Chat.cs
+++ b/HypnotoadPlugin/Offsets/Chat.cs
@@ -145,7 +145,7 @@ public static partial class Chat
     {
         if (_sanitiseString == null)
         {
-            throw new InvalidOperationException("Could not find signature for chat sanitisation");
+            throw new InvalidOperationException("Could not find signature for chat sanitization");
         }
 
         var uText = Utf8String.FromString(text);

--- a/HypnotoadPlugin/Offsets/GfxSettings.cs
+++ b/HypnotoadPlugin/Offsets/GfxSettings.cs
@@ -2,9 +2,6 @@
  * Copyright(c) 2022 Ori @MidiBard2
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Dalamud.Game.Gui.Toast;
 using Dalamud.Game.Text.SeStringHandling;

--- a/HypnotoadPlugin/Offsets/GfxSettings.cs
+++ b/HypnotoadPlugin/Offsets/GfxSettings.cs
@@ -17,172 +17,172 @@ internal static class GfxSettings
 
     internal class AgentConfigSystem : AgentInterface
     {
-        private static unsafe ConfigModule* _configModule = Framework.Instance()->UIModule->GetConfigModule();
+        private static readonly unsafe ConfigModule* ConfigModule = Framework.Instance()->UIModule->GetConfigModule();
         public AgentConfigSystem(AgentInterface agentInterface) : base(agentInterface.Pointer, agentInterface.Id) { }
 
         public unsafe void ApplyGraphicSettings()
         {
             void OnToast(ref SeString message, ref ToastOptions options, ref bool handled)
             {
-                handled            =  true;
-                Api.ToastGui.Toast -= OnToast;
+                if (Api.ToastGui != null) Api.ToastGui.Toast -= OnToast;
             }
 
             var refreshConfigGraphicState = (delegate* unmanaged<nint, long>)Offsets.ApplyGraphicConfigsFunc;
-            var result = refreshConfigGraphicState(Pointer);
-            Api.ToastGui.Toast += OnToast;
+            var _ = refreshConfigGraphicState(Pointer);
+            if (Api.ToastGui != null) Api.ToastGui.Toast += OnToast;
         }
-        public static unsafe AtkValue* GetOptionValue(ConfigOption option) => _configModule->GetValue(option);
-        public static unsafe void SetOptionValue(ConfigOption option, int value) => _configModule->SetOption(option, value);
-        public static unsafe void ToggleBoolOptionValue(ConfigOption option) => _configModule->SetOption(option, GetOptionValue(option)->Byte == 0 ? 1 : 0);
 
-        private static int FPSInActive;
-        private static int originalObjQuantity;
-        private static int WaterWet_DX11;
-        private static int OcclusionCulling_DX11;
-        private static int LodType_DX11;
-        private static int ReflectionType_DX11;
-        private static int AntiAliasing_DX11;
-        private static int TranslucentQuality_DX11;
-        private static int GrassQuality_DX11;
-        private static int ParallaxOcclusion_DX11;
-        private static int Tessellation_DX11;
-        private static int GlareRepresentation_DX11;
-        private static int MapResolution_DX11;
-        private static int ShadowVisibilityTypeSelf_DX11;
-        private static int ShadowVisibilityTypeParty_DX11;
-        private static int ShadowVisibilityTypeOther_DX11;
-        private static int ShadowVisibilityTypeEnemy_DX11;
-        private static int ShadowLOD_DX11;
-        private static int ShadowTextureSizeType_DX11;
-        private static int ShadowCascadeCountType_DX11;
-        private static int ShadowSoftShadowType_DX11;
-        private static int TextureFilterQuality_DX11;
-        private static int TextureAnisotropicQuality_DX11;
-        private static int PhysicsTypeSelf_DX11;
-        private static int PhysicsTypeParty_DX11;
-        private static int PhysicsTypeOther_DX11;
-        private static int PhysicsTypeEnemy_DX11;
-        private static int RadialBlur_DX11;
-        private static int SSAO_DX11;
-        private static int Glare_DX11;
-        private static int DistortionWater_DX11;
+        private static unsafe AtkValue* GetOptionValue(ConfigOption option) => ConfigModule->GetValue(option);
+        public static unsafe void SetOptionValue(ConfigOption option, int value) => ConfigModule->SetOption(option, value);
+        public static unsafe void ToggleBoolOptionValue(ConfigOption option) => ConfigModule->SetOption(option, GetOptionValue(option)->Byte == 0 ? 1 : 0);
+
+        private static int _fpsInActive;
+        private static int _originalObjQuantity;
+        private static int _waterWetDx11;
+        private static int _occlusionCullingDx11;
+        private static int _lodTypeDx11;
+        private static int _reflectionTypeDx11;
+        private static int _antiAliasingDx11;
+        private static int _translucentQualityDx11;
+        private static int _grassQualityDx11;
+        private static int _parallaxOcclusionDx11;
+        private static int _tessellationDx11;
+        private static int _glareRepresentationDx11;
+        private static int _mapResolutionDx11;
+        private static int _shadowVisibilityTypeSelfDx11;
+        private static int _shadowVisibilityTypePartyDx11;
+        private static int _shadowVisibilityTypeOtherDx11;
+        private static int _shadowVisibilityTypeEnemyDx11;
+        private static int _shadowLodDx11;
+        private static int _shadowTextureSizeTypeDx11;
+        private static int _shadowCascadeCountTypeDx11;
+        private static int _shadowSoftShadowTypeDx11;
+        private static int _textureFilterQualityDx11;
+        private static int _textureAnisotropicQualityDx11;
+        private static int _physicsTypeSelfDx11;
+        private static int _physicsTypePartyDx11;
+        private static int _physicsTypeOtherDx11;
+        private static int _physicsTypeEnemyDx11;
+        private static int _radialBlurDx11;
+        private static int _ssaoDx11;
+        private static int _glareDx11;
+        private static int _distortionWaterDx11;
 
         public static bool CheckLowSettings()
         {
-            return originalObjQuantity == 4      &&
-                   WaterWet_DX11 == 0            &&
-                   OcclusionCulling_DX11 == 1    &&
-                   ReflectionType_DX11 == 3      &&
-                   GrassQuality_DX11 == 3        &&
-                   SSAO_DX11 == 4;
+            return _originalObjQuantity == 4      &&
+                   _waterWetDx11 == 0            &&
+                   _occlusionCullingDx11 == 1    &&
+                   _reflectionTypeDx11 == 3      &&
+                   _grassQualityDx11 == 3        &&
+                   _ssaoDx11 == 4;
         }
 
         public static unsafe void GetObjQuantity()
         {
-            FPSInActive                    = _configModule->GetIntValue(ConfigOption.FPSInActive);
-            originalObjQuantity            = _configModule->GetIntValue(ConfigOption.DisplayObjectLimitType);
-            WaterWet_DX11                  = _configModule->GetIntValue(ConfigOption.WaterWet_DX11);
-            OcclusionCulling_DX11          = _configModule->GetIntValue(ConfigOption.OcclusionCulling_DX11);
-            LodType_DX11                   = _configModule->GetIntValue(ConfigOption.LodType_DX11);
-            ReflectionType_DX11            = _configModule->GetIntValue(ConfigOption.ReflectionType_DX11);
-            AntiAliasing_DX11              = _configModule->GetIntValue(ConfigOption.AntiAliasing_DX11);
-            TranslucentQuality_DX11        = _configModule->GetIntValue(ConfigOption.TranslucentQuality_DX11);
-            GrassQuality_DX11              = _configModule->GetIntValue(ConfigOption.GrassQuality_DX11);
-            ParallaxOcclusion_DX11         = _configModule->GetIntValue(ConfigOption.ParallaxOcclusion_DX11);
-            Tessellation_DX11              = _configModule->GetIntValue(ConfigOption.Tessellation_DX11);
-            GlareRepresentation_DX11       = _configModule->GetIntValue(ConfigOption.GlareRepresentation_DX11);
-            MapResolution_DX11             = _configModule->GetIntValue(ConfigOption.MapResolution_DX11);
-            ShadowVisibilityTypeSelf_DX11  = _configModule->GetIntValue(ConfigOption.ShadowVisibilityTypeSelf_DX11);
-            ShadowVisibilityTypeParty_DX11 = _configModule->GetIntValue(ConfigOption.ShadowVisibilityTypeParty_DX11);
-            ShadowVisibilityTypeOther_DX11 = _configModule->GetIntValue(ConfigOption.ShadowVisibilityTypeOther_DX11);
-            ShadowVisibilityTypeEnemy_DX11 = _configModule->GetIntValue(ConfigOption.ShadowVisibilityTypeEnemy_DX11);
-            ShadowLOD_DX11                 = _configModule->GetIntValue(ConfigOption.ShadowLOD_DX11);
-            ShadowTextureSizeType_DX11     = _configModule->GetIntValue(ConfigOption.ShadowTextureSizeType_DX11);
-            ShadowCascadeCountType_DX11    = _configModule->GetIntValue(ConfigOption.ShadowCascadeCountType_DX11);
-            ShadowSoftShadowType_DX11      = _configModule->GetIntValue(ConfigOption.ShadowSoftShadowType_DX11);
-            TextureFilterQuality_DX11      = _configModule->GetIntValue(ConfigOption.TextureFilterQuality_DX11);
-            TextureAnisotropicQuality_DX11 = _configModule->GetIntValue(ConfigOption.TextureAnisotropicQuality_DX11);
-            PhysicsTypeSelf_DX11           = _configModule->GetIntValue(ConfigOption.PhysicsTypeSelf_DX11);
-            PhysicsTypeParty_DX11          = _configModule->GetIntValue(ConfigOption.PhysicsTypeParty_DX11);
-            PhysicsTypeOther_DX11          = _configModule->GetIntValue(ConfigOption.PhysicsTypeOther_DX11);
-            PhysicsTypeEnemy_DX11          = _configModule->GetIntValue(ConfigOption.PhysicsTypeEnemy_DX11);
-            RadialBlur_DX11                = _configModule->GetIntValue(ConfigOption.RadialBlur_DX11);
-            SSAO_DX11                      = _configModule->GetIntValue(ConfigOption.SSAO_DX11);
-            Glare_DX11                     = _configModule->GetIntValue(ConfigOption.Glare_DX11);
-            DistortionWater_DX11           = _configModule->GetIntValue(ConfigOption.DistortionWater_DX11);
+            _fpsInActive                   = ConfigModule->GetIntValue(ConfigOption.FPSInActive);
+            _originalObjQuantity           = ConfigModule->GetIntValue(ConfigOption.DisplayObjectLimitType);
+            _waterWetDx11                  = ConfigModule->GetIntValue(ConfigOption.WaterWet_DX11);
+            _occlusionCullingDx11          = ConfigModule->GetIntValue(ConfigOption.OcclusionCulling_DX11);
+            _lodTypeDx11                   = ConfigModule->GetIntValue(ConfigOption.LodType_DX11);
+            _reflectionTypeDx11            = ConfigModule->GetIntValue(ConfigOption.ReflectionType_DX11);
+            _antiAliasingDx11              = ConfigModule->GetIntValue(ConfigOption.AntiAliasing_DX11);
+            _translucentQualityDx11        = ConfigModule->GetIntValue(ConfigOption.TranslucentQuality_DX11);
+            _grassQualityDx11              = ConfigModule->GetIntValue(ConfigOption.GrassQuality_DX11);
+            _parallaxOcclusionDx11         = ConfigModule->GetIntValue(ConfigOption.ParallaxOcclusion_DX11);
+            _tessellationDx11              = ConfigModule->GetIntValue(ConfigOption.Tessellation_DX11);
+            _glareRepresentationDx11       = ConfigModule->GetIntValue(ConfigOption.GlareRepresentation_DX11);
+            _mapResolutionDx11             = ConfigModule->GetIntValue(ConfigOption.MapResolution_DX11);
+            _shadowVisibilityTypeSelfDx11  = ConfigModule->GetIntValue(ConfigOption.ShadowVisibilityTypeSelf_DX11);
+            _shadowVisibilityTypePartyDx11 = ConfigModule->GetIntValue(ConfigOption.ShadowVisibilityTypeParty_DX11);
+            _shadowVisibilityTypeOtherDx11 = ConfigModule->GetIntValue(ConfigOption.ShadowVisibilityTypeOther_DX11);
+            _shadowVisibilityTypeEnemyDx11 = ConfigModule->GetIntValue(ConfigOption.ShadowVisibilityTypeEnemy_DX11);
+            _shadowLodDx11                 = ConfigModule->GetIntValue(ConfigOption.ShadowLOD_DX11);
+            _shadowTextureSizeTypeDx11     = ConfigModule->GetIntValue(ConfigOption.ShadowTextureSizeType_DX11);
+            _shadowCascadeCountTypeDx11    = ConfigModule->GetIntValue(ConfigOption.ShadowCascadeCountType_DX11);
+            _shadowSoftShadowTypeDx11      = ConfigModule->GetIntValue(ConfigOption.ShadowSoftShadowType_DX11);
+            _textureFilterQualityDx11      = ConfigModule->GetIntValue(ConfigOption.TextureFilterQuality_DX11);
+            _textureAnisotropicQualityDx11 = ConfigModule->GetIntValue(ConfigOption.TextureAnisotropicQuality_DX11);
+            _physicsTypeSelfDx11           = ConfigModule->GetIntValue(ConfigOption.PhysicsTypeSelf_DX11);
+            _physicsTypePartyDx11          = ConfigModule->GetIntValue(ConfigOption.PhysicsTypeParty_DX11);
+            _physicsTypeOtherDx11          = ConfigModule->GetIntValue(ConfigOption.PhysicsTypeOther_DX11);
+            _physicsTypeEnemyDx11          = ConfigModule->GetIntValue(ConfigOption.PhysicsTypeEnemy_DX11);
+            _radialBlurDx11                = ConfigModule->GetIntValue(ConfigOption.RadialBlur_DX11);
+            _ssaoDx11                      = ConfigModule->GetIntValue(ConfigOption.SSAO_DX11);
+            _glareDx11                     = ConfigModule->GetIntValue(ConfigOption.Glare_DX11);
+            _distortionWaterDx11           = ConfigModule->GetIntValue(ConfigOption.DistortionWater_DX11);
         }
 
         public static unsafe void SetMinimalObjQuantity()
         {
-            _configModule->SetOption(ConfigOption.FPSInActive, 0);
-            _configModule->SetOption(ConfigOption.DisplayObjectLimitType, 4);
+            ConfigModule->SetOption(ConfigOption.FPSInActive, 0);
+            ConfigModule->SetOption(ConfigOption.DisplayObjectLimitType, 4);
 
-            _configModule->SetOption(ConfigOption.WaterWet_DX11, 0);
-            _configModule->SetOption(ConfigOption.OcclusionCulling_DX11, 1);
-            _configModule->SetOption(ConfigOption.LodType_DX11, 1);
-            _configModule->SetOption(ConfigOption.ReflectionType_DX11, 3);
-            _configModule->SetOption(ConfigOption.AntiAliasing_DX11, 1);
-            _configModule->SetOption(ConfigOption.TranslucentQuality_DX11, 1);
-            _configModule->SetOption(ConfigOption.GrassQuality_DX11, 3);
-            _configModule->SetOption(ConfigOption.ParallaxOcclusion_DX11, 1);
-            _configModule->SetOption(ConfigOption.Tessellation_DX11, 1);
-            _configModule->SetOption(ConfigOption.GlareRepresentation_DX11, 1);
-            _configModule->SetOption(ConfigOption.MapResolution_DX11, 2);
-            _configModule->SetOption(ConfigOption.ShadowVisibilityTypeSelf_DX11, 1);
-            _configModule->SetOption(ConfigOption.ShadowVisibilityTypeParty_DX11, 1);
-            _configModule->SetOption(ConfigOption.ShadowVisibilityTypeOther_DX11, 1);
-            _configModule->SetOption(ConfigOption.ShadowVisibilityTypeEnemy_DX11, 1);
-            _configModule->SetOption(ConfigOption.ShadowLOD_DX11, 1);
-            _configModule->SetOption(ConfigOption.ShadowTextureSizeType_DX11, 2);
-            _configModule->SetOption(ConfigOption.ShadowCascadeCountType_DX11, 2);
-            _configModule->SetOption(ConfigOption.ShadowSoftShadowType_DX11, 1);
-            _configModule->SetOption(ConfigOption.TextureFilterQuality_DX11, 2);
-            _configModule->SetOption(ConfigOption.TextureAnisotropicQuality_DX11, 2);
-            _configModule->SetOption(ConfigOption.PhysicsTypeSelf_DX11, 2);
-            _configModule->SetOption(ConfigOption.PhysicsTypeParty_DX11, 2);
-            _configModule->SetOption(ConfigOption.PhysicsTypeOther_DX11, 2);
-            _configModule->SetOption(ConfigOption.PhysicsTypeEnemy_DX11, 2);
-            _configModule->SetOption(ConfigOption.RadialBlur_DX11, 0);
-            _configModule->SetOption(ConfigOption.SSAO_DX11, 4);
-            _configModule->SetOption(ConfigOption.Glare_DX11, 2);
-            _configModule->SetOption(ConfigOption.DistortionWater_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.WaterWet_DX11, 0);
+            ConfigModule->SetOption(ConfigOption.OcclusionCulling_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.LodType_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.ReflectionType_DX11, 3);
+            ConfigModule->SetOption(ConfigOption.AntiAliasing_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.TranslucentQuality_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.GrassQuality_DX11, 3);
+            ConfigModule->SetOption(ConfigOption.ParallaxOcclusion_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.Tessellation_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.GlareRepresentation_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.MapResolution_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.ShadowVisibilityTypeSelf_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.ShadowVisibilityTypeParty_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.ShadowVisibilityTypeOther_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.ShadowVisibilityTypeEnemy_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.ShadowLOD_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.ShadowTextureSizeType_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.ShadowCascadeCountType_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.ShadowSoftShadowType_DX11, 1);
+            ConfigModule->SetOption(ConfigOption.TextureFilterQuality_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.TextureAnisotropicQuality_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.PhysicsTypeSelf_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.PhysicsTypeParty_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.PhysicsTypeOther_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.PhysicsTypeEnemy_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.RadialBlur_DX11, 0);
+            ConfigModule->SetOption(ConfigOption.SSAO_DX11, 4);
+            ConfigModule->SetOption(ConfigOption.Glare_DX11, 2);
+            ConfigModule->SetOption(ConfigOption.DistortionWater_DX11, 2);
 
         }
 
         public static unsafe void RestoreObjQuantity()
         {
-            _configModule->SetOption(ConfigOption.FPSInActive,                      FPSInActive);
-            _configModule->SetOption(ConfigOption.DisplayObjectLimitType,           originalObjQuantity);
-            _configModule->SetOption(ConfigOption.WaterWet_DX11,                    WaterWet_DX11);
-            _configModule->SetOption(ConfigOption.OcclusionCulling_DX11,            OcclusionCulling_DX11);
-            _configModule->SetOption(ConfigOption.LodType_DX11,                     LodType_DX11);
-            _configModule->SetOption(ConfigOption.ReflectionType_DX11,              ReflectionType_DX11);
-            _configModule->SetOption(ConfigOption.AntiAliasing_DX11,                AntiAliasing_DX11);
-            _configModule->SetOption(ConfigOption.TranslucentQuality_DX11,          TranslucentQuality_DX11);
-            _configModule->SetOption(ConfigOption.GrassQuality_DX11,                GrassQuality_DX11);
-            _configModule->SetOption(ConfigOption.ParallaxOcclusion_DX11,           ParallaxOcclusion_DX11);
-            _configModule->SetOption(ConfigOption.Tessellation_DX11,                Tessellation_DX11);
-            _configModule->SetOption(ConfigOption.GlareRepresentation_DX11,         GlareRepresentation_DX11);
-            _configModule->SetOption(ConfigOption.MapResolution_DX11,               MapResolution_DX11);
-            _configModule->SetOption(ConfigOption.ShadowVisibilityTypeSelf_DX11,    ShadowVisibilityTypeSelf_DX11);
-            _configModule->SetOption(ConfigOption.ShadowVisibilityTypeParty_DX11,   ShadowVisibilityTypeParty_DX11);
-            _configModule->SetOption(ConfigOption.ShadowVisibilityTypeOther_DX11,   ShadowVisibilityTypeOther_DX11);
-            _configModule->SetOption(ConfigOption.ShadowVisibilityTypeEnemy_DX11,   ShadowVisibilityTypeEnemy_DX11);
-            _configModule->SetOption(ConfigOption.ShadowLOD_DX11,                   ShadowLOD_DX11);
-            _configModule->SetOption(ConfigOption.ShadowTextureSizeType_DX11,       ShadowTextureSizeType_DX11);
-            _configModule->SetOption(ConfigOption.ShadowCascadeCountType_DX11,      ShadowCascadeCountType_DX11);
-            _configModule->SetOption(ConfigOption.ShadowSoftShadowType_DX11,        ShadowSoftShadowType_DX11);
-            _configModule->SetOption(ConfigOption.TextureFilterQuality_DX11,        TextureFilterQuality_DX11);
-            _configModule->SetOption(ConfigOption.TextureAnisotropicQuality_DX11,   TextureAnisotropicQuality_DX11);
-            _configModule->SetOption(ConfigOption.PhysicsTypeSelf_DX11,             PhysicsTypeSelf_DX11);
-            _configModule->SetOption(ConfigOption.PhysicsTypeParty_DX11,            PhysicsTypeParty_DX11);
-            _configModule->SetOption(ConfigOption.PhysicsTypeOther_DX11,            PhysicsTypeOther_DX11);
-            _configModule->SetOption(ConfigOption.PhysicsTypeEnemy_DX11,            PhysicsTypeEnemy_DX11);
-            _configModule->SetOption(ConfigOption.RadialBlur_DX11,                  RadialBlur_DX11);
-            _configModule->SetOption(ConfigOption.SSAO_DX11,                        SSAO_DX11);
-            _configModule->SetOption(ConfigOption.Glare_DX11,                       Glare_DX11);
-            _configModule->SetOption(ConfigOption.DistortionWater_DX11,             DistortionWater_DX11);
+            ConfigModule->SetOption(ConfigOption.FPSInActive,                      _fpsInActive);
+            ConfigModule->SetOption(ConfigOption.DisplayObjectLimitType,           _originalObjQuantity);
+            ConfigModule->SetOption(ConfigOption.WaterWet_DX11,                    _waterWetDx11);
+            ConfigModule->SetOption(ConfigOption.OcclusionCulling_DX11,            _occlusionCullingDx11);
+            ConfigModule->SetOption(ConfigOption.LodType_DX11,                     _lodTypeDx11);
+            ConfigModule->SetOption(ConfigOption.ReflectionType_DX11,              _reflectionTypeDx11);
+            ConfigModule->SetOption(ConfigOption.AntiAliasing_DX11,                _antiAliasingDx11);
+            ConfigModule->SetOption(ConfigOption.TranslucentQuality_DX11,          _translucentQualityDx11);
+            ConfigModule->SetOption(ConfigOption.GrassQuality_DX11,                _grassQualityDx11);
+            ConfigModule->SetOption(ConfigOption.ParallaxOcclusion_DX11,           _parallaxOcclusionDx11);
+            ConfigModule->SetOption(ConfigOption.Tessellation_DX11,                _tessellationDx11);
+            ConfigModule->SetOption(ConfigOption.GlareRepresentation_DX11,         _glareRepresentationDx11);
+            ConfigModule->SetOption(ConfigOption.MapResolution_DX11,               _mapResolutionDx11);
+            ConfigModule->SetOption(ConfigOption.ShadowVisibilityTypeSelf_DX11,    _shadowVisibilityTypeSelfDx11);
+            ConfigModule->SetOption(ConfigOption.ShadowVisibilityTypeParty_DX11,   _shadowVisibilityTypePartyDx11);
+            ConfigModule->SetOption(ConfigOption.ShadowVisibilityTypeOther_DX11,   _shadowVisibilityTypeOtherDx11);
+            ConfigModule->SetOption(ConfigOption.ShadowVisibilityTypeEnemy_DX11,   _shadowVisibilityTypeEnemyDx11);
+            ConfigModule->SetOption(ConfigOption.ShadowLOD_DX11,                   _shadowLodDx11);
+            ConfigModule->SetOption(ConfigOption.ShadowTextureSizeType_DX11,       _shadowTextureSizeTypeDx11);
+            ConfigModule->SetOption(ConfigOption.ShadowCascadeCountType_DX11,      _shadowCascadeCountTypeDx11);
+            ConfigModule->SetOption(ConfigOption.ShadowSoftShadowType_DX11,        _shadowSoftShadowTypeDx11);
+            ConfigModule->SetOption(ConfigOption.TextureFilterQuality_DX11,        _textureFilterQualityDx11);
+            ConfigModule->SetOption(ConfigOption.TextureAnisotropicQuality_DX11,   _textureAnisotropicQualityDx11);
+            ConfigModule->SetOption(ConfigOption.PhysicsTypeSelf_DX11,             _physicsTypeSelfDx11);
+            ConfigModule->SetOption(ConfigOption.PhysicsTypeParty_DX11,            _physicsTypePartyDx11);
+            ConfigModule->SetOption(ConfigOption.PhysicsTypeOther_DX11,            _physicsTypeOtherDx11);
+            ConfigModule->SetOption(ConfigOption.PhysicsTypeEnemy_DX11,            _physicsTypeEnemyDx11);
+            ConfigModule->SetOption(ConfigOption.RadialBlur_DX11,                  _radialBlurDx11);
+            ConfigModule->SetOption(ConfigOption.SSAO_DX11,                        _ssaoDx11);
+            ConfigModule->SetOption(ConfigOption.Glare_DX11,                       _glareDx11);
+            ConfigModule->SetOption(ConfigOption.DistortionWater_DX11,             _distortionWaterDx11);
 
 
         }
@@ -212,7 +212,7 @@ public unsafe class AgentInterface
 
 internal unsafe class AgentManager
 {
-    internal List<AgentInterface> AgentTable { get; } = new(400);
+    private List<AgentInterface> AgentTable { get; } = new(400);
 
     private AgentManager()
     {

--- a/HypnotoadPlugin/Offsets/NetworkReader.cs
+++ b/HypnotoadPlugin/Offsets/NetworkReader.cs
@@ -2,29 +2,28 @@
 using System.IO;
 using Dalamud.Game.Network;
 
-namespace HypnotoadPlugin.Offsets
+namespace HypnotoadPlugin.Offsets;
+
+public static unsafe class NetworkReader
 {
-    public static unsafe class NetworkReader
+    public static void NetworkMessage(nint dataPtr, ushort opCode, uint sourceActorId, uint targetActorId, NetworkMessageDirection direction)
     {
-        public static void NetworkMessage(nint dataPtr, ushort opCode, uint sourceActorId, uint targetActorId, NetworkMessageDirection direction)
-        {
-            if (direction == NetworkMessageDirection.ZoneDown && Pipe.Client != null && Pipe.Client.IsConnected)
-                Pipe.Client.WriteAsync(new Message
-                {
-                    msgType = MessageType.NetworkPacket,
-                    message = Environment.ProcessId + ":" + Convert.ToBase64String(GetPacket(dataPtr))
-                });
-        }
+        if (direction == NetworkMessageDirection.ZoneDown && Pipe.Client is { IsConnected: true })
+            Pipe.Client.WriteAsync(new Message
+            {
+                msgType = MessageType.NetworkPacket,
+                message = Environment.ProcessId + ":" + Convert.ToBase64String(GetPacket(dataPtr))
+            });
+    }
 
-        internal static void Initialize() => Api.GameNetwork.NetworkMessage += NetworkMessage;
-        internal static void Dispose() => Api.GameNetwork.NetworkMessage -= NetworkMessage;
+    internal static void Initialize() => Api.GameNetwork.NetworkMessage += NetworkMessage;
+    internal static void Dispose() => Api.GameNetwork.NetworkMessage -= NetworkMessage;
 
-        private static unsafe byte[] GetPacket(IntPtr dataPtr)
-        {
-            using var memoryStream = new MemoryStream();
-            using var unmanagedMemoryStream = new UnmanagedMemoryStream((byte*)(dataPtr - 0x20).ToPointer(), 4096);
-            unmanagedMemoryStream.CopyTo(memoryStream);
-            return memoryStream.ToArray();
-        }
+    private static byte[] GetPacket(IntPtr dataPtr)
+    {
+        using var memoryStream = new MemoryStream();
+        using var unmanagedMemoryStream = new UnmanagedMemoryStream((byte*)(dataPtr - 0x20).ToPointer(), 4096);
+        unmanagedMemoryStream.CopyTo(memoryStream);
+        return memoryStream.ToArray();
     }
 }

--- a/HypnotoadPlugin/Offsets/NetworkReader.cs
+++ b/HypnotoadPlugin/Offsets/NetworkReader.cs
@@ -4,18 +4,25 @@ namespace HypnotoadPlugin.Offsets;
 
 public static unsafe class NetworkReader
 {
-    public static void NetworkMessage(nint dataPtr, ushort opCode, uint sourceActorId, uint targetActorId, NetworkMessageDirection direction)
+    private static void NetworkMessage(nint dataPtr, ushort opCode, uint sourceActorId, uint targetActorId, NetworkMessageDirection direction)
     {
         if (direction == NetworkMessageDirection.ZoneDown && Pipe.Client is { IsConnected: true })
-            Pipe.Client.WriteAsync(new Message
+            Pipe.Client.WriteAsync(new PayloadMessage
             {
-                msgType = MessageType.NetworkPacket,
-                message = Environment.ProcessId + ":" + Convert.ToBase64String(GetPacket(dataPtr))
+                MsgType = MessageType.NetworkPacket,
+                Message = Environment.ProcessId + ":" + Convert.ToBase64String(GetPacket(dataPtr))
             });
     }
 
-    internal static void Initialize() => Api.GameNetwork.NetworkMessage += NetworkMessage;
-    internal static void Dispose() => Api.GameNetwork.NetworkMessage -= NetworkMessage;
+    internal static void Initialize()
+    {
+        if (Api.GameNetwork != null) Api.GameNetwork.NetworkMessage += NetworkMessage;
+    }
+
+    internal static void Dispose()
+    {
+        if (Api.GameNetwork != null) Api.GameNetwork.NetworkMessage -= NetworkMessage;
+    }
 
     private static byte[] GetPacket(IntPtr dataPtr)
     {

--- a/HypnotoadPlugin/Offsets/NetworkReader.cs
+++ b/HypnotoadPlugin/Offsets/NetworkReader.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using Dalamud.Game.Network;
+﻿using Dalamud.Game.Network;
 
 namespace HypnotoadPlugin.Offsets;
 

--- a/HypnotoadPlugin/Offsets/OffsetManager.cs
+++ b/HypnotoadPlugin/Offsets/OffsetManager.cs
@@ -2,9 +2,6 @@
  * Copyright(c) 2022 Ori @MidiBard2
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Dalamud.Game;

--- a/HypnotoadPlugin/Offsets/Offsets.cs
+++ b/HypnotoadPlugin/Offsets/Offsets.cs
@@ -57,26 +57,26 @@ public static class Offsets
 public sealed unsafe class AgentPerformance : AgentInterface
 {
     public AgentPerformance(AgentInterface agentInterface) : base(agentInterface.Pointer, agentInterface.Id) { }
-    public static AgentPerformance Instance => Hypnotoad.AgentPerformance;
+    public static AgentPerformance? Instance => Hypnotoad.AgentPerformance;
     public new AgentPerformanceStruct* Struct => (AgentPerformanceStruct*)Pointer;
 
     [StructLayout(LayoutKind.Explicit)]
     public struct AgentPerformanceStruct
     {
-        [FieldOffset(0)] public FFXIVClientStructs.FFXIV.Component.GUI.AgentInterface AgentInterface;
-        [FieldOffset(0x20)] public byte InPerformanceMode;
-        [FieldOffset(0x38)] public long PerformanceTimer1;
-        [FieldOffset(0x40)] public long PerformanceTimer2;
+        [FieldOffset(0)] private readonly FFXIVClientStructs.FFXIV.Component.GUI.AgentInterface AgentInterface;
+        [FieldOffset(0x20)] public readonly byte InPerformanceMode;
+        [FieldOffset(0x38)] public readonly long PerformanceTimer1;
+        [FieldOffset(0x40)] public readonly long PerformanceTimer2;
         [FieldOffset(0x5C)] public int NoteOffset;
         [FieldOffset(0x60)] public int CurrentPressingNote;
         [FieldOffset(0xFC)] public int OctaveOffset;
-        [FieldOffset(0x1B0)] public int GroupTone;
+        [FieldOffset(0x1B0)] public readonly int GroupTone;
     }
 
     internal int CurrentGroupTone => Struct->GroupTone;
     internal bool InPerformanceMode => Struct->InPerformanceMode != 0;
-    internal bool notePressed => Struct->CurrentPressingNote != -100;
-    internal int noteNumber => Struct->CurrentPressingNote;
+    internal bool NotePressed => Struct->CurrentPressingNote != -100;
+    internal int NoteNumber => Struct->CurrentPressingNote;
     internal long PerformanceTimer1 => Struct->PerformanceTimer1;
     internal long PerformanceTimer2 => Struct->PerformanceTimer2;
 }

--- a/HypnotoadPlugin/Offsets/PerformActions.cs
+++ b/HypnotoadPlugin/Offsets/PerformActions.cs
@@ -2,10 +2,7 @@
  * Copyright(c) 2022 Ori @MidiBard2
  */
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Dalamud.Logging;
 using Dalamud.Utility.Signatures;

--- a/HypnotoadPlugin/Offsets/PerformActions.cs
+++ b/HypnotoadPlugin/Offsets/PerformActions.cs
@@ -12,35 +12,36 @@ namespace HypnotoadPlugin.Offsets;
 
 public class PerformActions
 {
-    internal delegate void DoPerformActionDelegate(nint performInfoPtr, uint instrumentId, int a3 = 0);
-    private static DoPerformActionDelegate doPerformAction { get; } = Marshal.GetDelegateForFunctionPointer<DoPerformActionDelegate>(Offsets.DoPerformAction);
-    public static void DoPerformAction(uint instrumentId)
+    private delegate void DoPerformActionDelegate(nint performInfoPtr, uint instrumentId, int a3 = 0);
+    private static DoPerformActionDelegate DoPerformAction { get; } = Marshal.GetDelegateForFunctionPointer<DoPerformActionDelegate>(Offsets.DoPerformAction);
+    public static void PerformAction(uint instrumentId)
     {
-        PluginLog.Information($"[DoPerformAction] instrumentId: {instrumentId}");
-        doPerformAction(Offsets.PerformanceStructPtr, instrumentId);
+        PluginLog.Information($"[PerformAction] instrumentId: {instrumentId}");
+        DoPerformAction(Offsets.PerformanceStructPtr, instrumentId);
     }
 
     private PerformActions() { }
     private static unsafe nint GetWindowByName(string s) => (nint)AtkStage.GetSingleton()->RaptureAtkUnitManager->GetAddonByName(s);
-    public static void init() => SignatureHelper.Initialise(new PerformActions());
-    public static void SendAction(nint ptr, params ulong[] param)
+    public static void Init() => SignatureHelper.Initialise(new PerformActions());
+
+    private static void SendAction(nint ptr, params ulong[] param)
     {
         if (param.Length % 2 != 0) 
             throw new ArgumentException("The parameter length must be an integer multiple of 2.");
         if (ptr == nint.Zero) 
             throw new ArgumentException("input pointer is null");
 
-        var paircount = param.Length / 2;
+        var pairCount = param.Length / 2;
         unsafe
         {
             fixed (ulong* u = param)
             {
-                AtkUnitBase.MemberFunctionPointers.FireCallback((AtkUnitBase*)ptr, paircount, (AtkValue*)u, (void*)1);
+                AtkUnitBase.MemberFunctionPointers.FireCallback((AtkUnitBase*)ptr, pairCount, (AtkValue*)u, (void*)1);
             }
         }
     }
 
-    public static bool SendAction(string name, params ulong[] param)
+    private static bool SendAction(string name, params ulong[] param)
     {
         var ptr = GetWindowByName(name);
         if (ptr == nint.Zero) return false;
@@ -48,7 +49,7 @@ public class PerformActions
         return true;
     }
 
-    public static bool PressKey(int keynumber, ref int offset, ref int octave)
+    private static bool PressKey(int keyNumber, ref int offset, ref int octave)
     {
         if (!TargetWindowPtr(out var miniMode, out var targetWindowPtr)) return false;
         offset = 0;
@@ -56,60 +57,60 @@ public class PerformActions
 
         if (miniMode)
         {
-            keynumber = ConvertMiniKeyNumber(keynumber, ref offset, ref octave);
+            keyNumber = ConvertMiniKeyNumber(keyNumber, ref offset, ref octave);
         }
 
-        SendAction(targetWindowPtr, 3, 1, 4, (ulong)keynumber);
+        SendAction(targetWindowPtr, 3, 1, 4, (ulong)keyNumber);
 
         return true;
 
     }
 
-    public static bool ReleaseKey(int keynumber)
+    private static bool ReleaseKey(int keyNumber)
     {
         if (!TargetWindowPtr(out var miniMode, out var targetWindowPtr)) return false;
-        if (miniMode) keynumber = ConvertMiniKeyNumber(keynumber);
+        if (miniMode) keyNumber = ConvertMiniKeyNumber(keyNumber);
 
-        SendAction(targetWindowPtr, 3, 2, 4, (ulong)keynumber);
+        SendAction(targetWindowPtr, 3, 2, 4, (ulong)keyNumber);
 
         return true;
 
     }
 
-    private static int ConvertMiniKeyNumber(int keynumber)
+    private static int ConvertMiniKeyNumber(int keyNumber)
     {
-        keynumber -= 12;
-        switch (keynumber)
+        keyNumber -= 12;
+        switch (keyNumber)
         {
             case < 0:
-                keynumber += 12;
+                keyNumber += 12;
                 break;
             case > 12:
-                keynumber -= 12;
+                keyNumber -= 12;
                 break;
         }
 
-        return keynumber;
+        return keyNumber;
     }
 
-    private static int ConvertMiniKeyNumber(int keynumber, ref int offset, ref int octave)
+    private static int ConvertMiniKeyNumber(int keyNumber, ref int offset, ref int octave)
     {
-        keynumber -= 12;
-        switch (keynumber)
+        keyNumber -= 12;
+        switch (keyNumber)
         {
             case < 0:
-                keynumber += 12;
+                keyNumber += 12;
                 offset    =  -12;
                 octave    =  -1;
                 break;
             case > 12:
-                keynumber -= 12;
+                keyNumber -= 12;
                 offset    =  12;
                 octave    =  1;
                 break;
         }
 
-        return keynumber;
+        return keyNumber;
     }
 
     private static bool TargetWindowPtr(out bool miniMode, out nint targetWindowPtr)
@@ -164,11 +165,11 @@ public class PerformActions
     {
         if (on)
         {
-            if (Hypnotoad.AgentPerformance.noteNumber - 39 == noteNum)
+            if (Hypnotoad.AgentPerformance != null && Hypnotoad.AgentPerformance.NoteNumber - 39 == noteNum)
                 if (ReleaseKey(noteNum))
                     Hypnotoad.AgentPerformance.Struct->CurrentPressingNote = -100;
 
-            if (PressKey(noteNum, ref Hypnotoad.AgentPerformance.Struct->NoteOffset, ref Hypnotoad.AgentPerformance.Struct->OctaveOffset))
+            if (Hypnotoad.AgentPerformance != null && PressKey(noteNum, ref Hypnotoad.AgentPerformance.Struct->NoteOffset, ref Hypnotoad.AgentPerformance.Struct->OctaveOffset))
             {
                 Hypnotoad.AgentPerformance.Struct->CurrentPressingNote = noteNum + 39;
             }
@@ -176,12 +177,12 @@ public class PerformActions
         }
         else
         {
-            if (Hypnotoad.AgentPerformance.Struct->CurrentPressingNote - 39 != noteNum)
+            if (Hypnotoad.AgentPerformance != null && Hypnotoad.AgentPerformance.Struct->CurrentPressingNote - 39 != noteNum)
                 return;
 
             if (ReleaseKey(noteNum))
             {
-                Hypnotoad.AgentPerformance.Struct->CurrentPressingNote = -100;
+                if (Hypnotoad.AgentPerformance != null) Hypnotoad.AgentPerformance.Struct->CurrentPressingNote = -100;
             }
         }
     }

--- a/HypnotoadPlugin/Offsets/api.cs
+++ b/HypnotoadPlugin/Offsets/api.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 using Dalamud.Data;
 using Dalamud.Game;
 using Dalamud.Game.ClientState;

--- a/HypnotoadPlugin/Offsets/api.cs
+++ b/HypnotoadPlugin/Offsets/api.cs
@@ -29,101 +29,101 @@ public class Api
 {
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static DalamudPluginInterface PluginInterface { get; private set; }
+    public static DalamudPluginInterface? PluginInterface { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static BuddyList BuddyList { get; private set; }
+    public static BuddyList? BuddyList { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static ChatGui ChatGui { get; private set; }
+    public static ChatGui? ChatGui { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static ChatHandlers ChatHandlers { get; private set; }
+    public static ChatHandlers? ChatHandlers { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static ClientState ClientState { get; private set; }
+    public static ClientState? ClientState { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static CommandManager CommandManager { get; private set; }
+    public static CommandManager? CommandManager { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static Condition Condition { get; private set; }
+    public static Condition? Condition { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static DataManager DataManager { get; private set; }
+    public static DataManager? DataManager { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static FateTable FateTable { get; private set; }
+    public static FateTable? FateTable { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static FlyTextGui FlyTextGui { get; private set; }
+    public static FlyTextGui? FlyTextGui { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static Framework Framework { get; private set; }
+    public static Framework? Framework { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static GameGui GameGui { get; private set; }
+    public static GameGui? GameGui { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static GameNetwork GameNetwork { get; private set; }
+    public static GameNetwork? GameNetwork { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static JobGauges JobGauges { get; private set; }
+    public static JobGauges? JobGauges { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static KeyState KeyState { get; private set; }
+    public static KeyState? KeyState { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static LibcFunction LibcFunction { get; private set; }
+    public static LibcFunction? LibcFunction { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static ObjectTable ObjectTable { get; private set; }
+    public static ObjectTable? ObjectTable { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static PartyFinderGui PartyFinderGui { get; private set; }
+    public static PartyFinderGui? PartyFinderGui { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static PartyList PartyList { get; private set; }
+    public static PartyList? PartyList { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static SigScanner SigScanner { get; private set; }
+    public static SigScanner? SigScanner { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static TargetManager TargetManager { get; private set; }
+    public static TargetManager? TargetManager { get; private set; }
 
     [PluginService]
     //[RequiredVersion("1.0")]
-    public static ToastGui ToastGui { get; private set; }
+    public static ToastGui? ToastGui { get; private set; }
 
-    private static PluginCommandManager<IDalamudPlugin> _pluginCommandManager;
+    private static PluginCommandManager<IDalamudPlugin>? _pluginCommandManager;
 
     public Api() { }
 
     public Api(IDalamudPlugin plugin) => _pluginCommandManager ??= new PluginCommandManager<IDalamudPlugin>(plugin);
 
-    public Api(IDalamudPlugin plugin, DalamudPluginInterface pluginInterface)
+    private Api(IDalamudPlugin plugin, DalamudPluginInterface? pluginInterface)
     {
-        if (!pluginInterface.Inject(this))
+        if (pluginInterface != null && !pluginInterface.Inject(this))
         {
             PluginLog.LogError("Failed loading DalamudApi!");
             return;
@@ -144,7 +144,7 @@ public class Api
         throw new InvalidOperationException();
     }
 
-    public static void Initialize(IDalamudPlugin plugin, DalamudPluginInterface pluginInterface) => _ = new Api(plugin, pluginInterface);
+    public static void Initialize(IDalamudPlugin plugin, DalamudPluginInterface? pluginInterface) => _ = new Api(plugin, pluginInterface);
 
     public static void Dispose() => _pluginCommandManager?.Dispose();
 }
@@ -169,13 +169,13 @@ public class PluginCommandManager<T> : IDisposable where T : IDalamudPlugin
     private void AddCommandHandlers()
     {
         foreach (var (command, commandInfo) in _pluginCommands)
-            Api.CommandManager.AddHandler(command, commandInfo);
+            Api.CommandManager?.AddHandler(command, commandInfo);
     }
 
     private void RemoveCommandHandlers()
     {
         foreach (var (command, _) in _pluginCommands)
-            Api.CommandManager.RemoveHandler(command);
+            Api.CommandManager?.RemoveHandler(command);
     }
 
     private IEnumerable<(string, CommandInfo)> GetCommandInfoTuple(MethodInfo method)
@@ -194,7 +194,7 @@ public class PluginCommandManager<T> : IDisposable where T : IDalamudPlugin
         };
 
         // Create list of tuples that will be filled with one tuple per alias, in addition to the base command tuple.
-        var commandInfoTuples = new List<(string, CommandInfo)> { (command?.Command, commandInfo) };
+        var commandInfoTuples = new List<(string, CommandInfo)> { (command?.Command, commandInfo)! };
         if (aliases != null)
             commandInfoTuples.AddRange(aliases.Aliases.Select(alias => (alias, commandInfo)));
 
@@ -211,38 +211,38 @@ public class PluginCommandManager<T> : IDisposable where T : IDalamudPlugin
 
 #region Attributes
 [AttributeUsage(AttributeTargets.Method)]
-public class AliasesAttribute : Attribute
+public abstract class AliasesAttribute : Attribute
 {
     public string[] Aliases { get; }
 
-    public AliasesAttribute(params string[] aliases)
+    protected AliasesAttribute(params string[] aliases)
     {
         Aliases = aliases;
     }
 }
 
 [AttributeUsage(AttributeTargets.Method)]
-public class CommandAttribute : Attribute
+public abstract class CommandAttribute : Attribute
 {
     public string Command { get; }
 
-    public CommandAttribute(string command)
+    protected CommandAttribute(string command)
     {
         Command = command;
     }
 }
 
 [AttributeUsage(AttributeTargets.Method)]
-public class DoNotShowInHelpAttribute : Attribute
+public abstract class DoNotShowInHelpAttribute : Attribute
 {
 }
 
 [AttributeUsage(AttributeTargets.Method)]
-public class HelpMessageAttribute : Attribute
+public abstract class HelpMessageAttribute : Attribute
 {
     public string HelpMessage { get; }
 
-    public HelpMessageAttribute(string helpMessage)
+    protected HelpMessageAttribute(string helpMessage)
     {
         HelpMessage = helpMessage;
     }

--- a/HypnotoadPlugin/Pipe.cs
+++ b/HypnotoadPlugin/Pipe.cs
@@ -5,11 +5,11 @@ namespace HypnotoadPlugin;
 
 internal static class Pipe
 {
-    internal static PipeClient<Message> Client { get; private set; }
+    internal static PipeClient<PayloadMessage>? Client { get; private set; }
 
     internal static void Initialize()
     {
-        Client = new PipeClient<Message>("Hypnotoad", formatter: new NewtonsoftJsonFormatter());
+        Client = new PipeClient<PayloadMessage>("Hypnotoad", formatter: new NewtonsoftJsonFormatter());
     }
 
     internal static void Dispose()

--- a/HypnotoadPlugin/Pipe.cs
+++ b/HypnotoadPlugin/Pipe.cs
@@ -1,21 +1,19 @@
 ﻿using H.Formatters;
 using H.Pipes;
-using System.ComponentModel.Design;
 
-namespace HypnotoadPlugin
+namespace HypnotoadPlugin;
+
+internal static class Pipe
 {
-    internal static class Pipe
+    internal static PipeClient<Message> Client { get; private set; }
+
+    internal static void Initialize()
     {
-        internal static PipeClient<Message> Client { get; private set; }
+        Client = new PipeClient<Message>("Hypnotoad", formatter: new NewtonsoftJsonFormatter());
+    }
 
-        internal static void Initialize()
-        {
-            Client = new PipeClient<Message>("Hypnotoad", formatter: new NewtonsoftJsonFormatter());
-        }
+    internal static void Dispose()
+    {
 
-        internal static void Dispose()
-        {
-
-        }
     }
 }

--- a/HypnotoadPlugin/Plugin.cs
+++ b/HypnotoadPlugin/Plugin.cs
@@ -40,7 +40,7 @@ public class Hypnotoad : IDalamudPlugin
 
         CommandManager.AddHandler(commandName, new CommandInfo(OnCommand)
         {
-            HelpMessage = "A useful message to display in /xlhelp"
+            HelpMessage = "Open the Hypnotoad settings menu."
         });
 
         AgentConfigSystem = new AgentConfigSystem(AgentManager.Instance.FindAgentInterfaceByVtable(Offsets.Offsets.AgentConfigSystem));

--- a/HypnotoadPlugin/Plugin.cs
+++ b/HypnotoadPlugin/Plugin.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Dalamud.Game;
+﻿using Dalamud.Game;
 using Dalamud.Game.Command;
 using Dalamud.Game.Gui;
 using Dalamud.IoC;

--- a/HypnotoadPlugin/Plugin.cs
+++ b/HypnotoadPlugin/Plugin.cs
@@ -37,9 +37,7 @@ public class Hypnotoad : IDalamudPlugin
         OffsetManager.Setup(SigScanner);
 
         // you might normally want to embed resources and load them from the manifest stream
-        var imagePath = Path.Combine(PluginInterface.AssemblyLocation.Directory?.FullName!, "icon.png");
-        var goatImage = PluginInterface.UiBuilder.LoadImage(imagePath);
-        PluginUi = new PluginUI(Configuration, goatImage);
+        PluginUi = new PluginUI(Configuration);
 
         CommandManager.AddHandler(commandName, new CommandInfo(OnCommand)
         {

--- a/HypnotoadPlugin/Plugin.cs
+++ b/HypnotoadPlugin/Plugin.cs
@@ -1,6 +1,5 @@
 ﻿using Dalamud.Game;
 using Dalamud.Game.Command;
-using Dalamud.Game.Gui;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using HypnotoadPlugin.Offsets;
@@ -13,19 +12,19 @@ public class Hypnotoad : IDalamudPlugin
     //public static XivCommonBase CBase;
     public string Name => "Hypnotoad";
 
-    private const string commandName = "/hypnotoad";
+    private const string CommandName = "/hypnotoad";
 
-    private DalamudPluginInterface PluginInterface { get; init; }
-    private CommandManager CommandManager { get; init; }
-    private Configuration Configuration { get; init; }
-    private PluginUI PluginUi { get; init; }
-    internal static AgentConfigSystem AgentConfigSystem { get; set; }
-    internal static AgentPerformance AgentPerformance { get; set; }
+    private DalamudPluginInterface PluginInterface { get; }
+    private CommandManager CommandManager { get; }
+    private Configuration Configuration { get; }
+    private PluginUi PluginUi { get; }
+    internal static AgentConfigSystem? AgentConfigSystem { get; private set; }
+    internal static AgentPerformance? AgentPerformance { get; private set; }
 
-    [PluginService]
-    public static SigScanner SigScanner { get; private set; }
+    [PluginService] 
+    private static SigScanner? SigScanner { get; set; }
 
-    public Hypnotoad(DalamudPluginInterface pluginInterface, CommandManager commandManager, ChatGui chatGui)
+    public Hypnotoad(DalamudPluginInterface pluginInterface, CommandManager commandManager)
     {
         Api.Initialize(this, pluginInterface);
         PluginInterface = pluginInterface;
@@ -36,9 +35,9 @@ public class Hypnotoad : IDalamudPlugin
         OffsetManager.Setup(SigScanner);
 
         // you might normally want to embed resources and load them from the manifest stream
-        PluginUi = new PluginUI(Configuration);
+        PluginUi = new PluginUi(Configuration);
 
-        CommandManager.AddHandler(commandName, new CommandInfo(OnCommand)
+        CommandManager.AddHandler(CommandName, new CommandInfo(OnCommand)
         {
             HelpMessage = "Open the Hypnotoad settings menu."
         });
@@ -47,8 +46,8 @@ public class Hypnotoad : IDalamudPlugin
         AgentPerformance  = new AgentPerformance(AgentManager.Instance.FindAgentInterfaceByVtable(Offsets.Offsets.AgentPerformance));
         AgentConfigSystem.GetObjQuantity();
 
-        PluginInterface.UiBuilder.Draw         += DrawUI;
-        PluginInterface.UiBuilder.OpenConfigUi += DrawConfigUI;
+        PluginInterface.UiBuilder.Draw         += DrawUi;
+        PluginInterface.UiBuilder.OpenConfigUi += DrawConfigUi;
         NetworkReader.Initialize();
     }
 
@@ -56,10 +55,10 @@ public class Hypnotoad : IDalamudPlugin
     {
         NetworkReader.Dispose();
         AgentConfigSystem.RestoreObjQuantity();
-        AgentConfigSystem.ApplyGraphicSettings();
+        AgentConfigSystem?.ApplyGraphicSettings();
 
         PluginUi.Dispose();
-        CommandManager.RemoveHandler(commandName);
+        CommandManager.RemoveHandler(CommandName);
     }
 
     private void OnCommand(string command, string args)
@@ -68,12 +67,12 @@ public class Hypnotoad : IDalamudPlugin
         PluginUi.Visible = true;
     }
 
-    private void DrawUI()
+    private void DrawUi()
     {
         PluginUi.Draw();
     }
 
-    private void DrawConfigUI()
+    private void DrawConfigUi()
     {
         PluginUi.Visible = true;
     }

--- a/HypnotoadPlugin/PluginUI.cs
+++ b/HypnotoadPlugin/PluginUI.cs
@@ -4,12 +4,9 @@ using System.Numerics;
 using System.Reflection;
 using System.Timers;
 using Dalamud.Logging;
-using H.Formatters;
-using H.Pipes;
 using H.Pipes.Args;
 using HypnotoadPlugin.Offsets;
 using ImGuiNET;
-using ImGuiScene;
 
 namespace HypnotoadPlugin;
 
@@ -40,21 +37,21 @@ class PluginUI : IDisposable
 
     public PluginUI(Configuration configuration)
     {
-        this.configuration          =  configuration;
+        this.configuration = configuration;
 
         Pipe.Initialize();
-        Pipe.Client.Connected += pipeClient_Connected;
+        Pipe.Client.Connected       += pipeClient_Connected;
         Pipe.Client.MessageReceived += pipeClient_MessageReceived;
-        Pipe.Client.Disconnected += pipeClient_Disconnected;
-        _reconnectTimer.Elapsed += reconnectTimer_Elapsed;
+        Pipe.Client.Disconnected    += pipeClient_Disconnected;
+        _reconnectTimer.Elapsed     += reconnectTimer_Elapsed;
 
-        _reconnectTimer.Interval    =  2000;
-        _reconnectTimer.Enabled     =  configuration.Autoconnect;
+        _reconnectTimer.Interval = 2000;
+        _reconnectTimer.Enabled  = configuration.Autoconnect;
 
         Visible = false;
     }
 
-    private void pipeClient_Connected(object sender, ConnectionEventArgs<Message> e)
+    private static void pipeClient_Connected(object sender, ConnectionEventArgs<Message> e)
     {
         Pipe.Client.WriteAsync(new Message
         {
@@ -66,9 +63,9 @@ class PluginUI : IDisposable
 
         Pipe.Client.WriteAsync(new Message
         {
-            msgType = MessageType.Version,
+            msgType    = MessageType.Version,
             msgChannel = 0,
-            message = Environment.ProcessId + ":" + Assembly.GetExecutingAssembly().GetName().Version.ToString()
+            message    = Environment.ProcessId + ":" + Assembly.GetExecutingAssembly().GetName().Version
         });
 
         Pipe.Client.WriteAsync(new Message
@@ -114,11 +111,11 @@ class PluginUI : IDisposable
         switch (inMsg.msgType)
         {
             case MessageType.Version:
-                if (new Version(inMsg.message) > Assembly.GetEntryAssembly().GetName().Version)
+                if (new Version(inMsg.message) > Assembly.GetEntryAssembly()?.GetName().Version)
                 {
                     ManuallyDisconnected = true;
                     Pipe.Client.DisconnectAsync();
-                    PluginLog.LogError($"Hypnotoad is out of date and cannot work with the running bard program.");
+                    PluginLog.LogError("Hypnotoad is out of date and cannot work with the running bard program.");
                 }
                 break;
             case MessageType.NoteOn:

--- a/HypnotoadPlugin/PluginUI.cs
+++ b/HypnotoadPlugin/PluginUI.cs
@@ -28,8 +28,6 @@ class PluginUI : IDisposable
     private Queue<Message> qt = new();
     private Configuration configuration;
 
-    private TextureWrap goatImage;
-
     // this extra bool exists for ImGui, since you can't ref a property
     private bool visible;
     public bool Visible
@@ -40,11 +38,9 @@ class PluginUI : IDisposable
 
     public bool ManuallyDisconnected { get; set; }
 
-    // passing in the image here just for simplicity
-    public PluginUI(Configuration configuration, TextureWrap goatImage)
+    public PluginUI(Configuration configuration)
     {
         this.configuration          =  configuration;
-        this.goatImage              =  goatImage;
 
         Pipe.Initialize();
         Pipe.Client.Connected += pipeClient_Connected;
@@ -150,7 +146,6 @@ class PluginUI : IDisposable
         Pipe.Client.DisconnectAsync();
         Pipe.Client.DisposeAsync();
         Pipe.Dispose();
-        goatImage.Dispose();
     }
 
     public void Draw()

--- a/HypnotoadPlugin/PluginUI.cs
+++ b/HypnotoadPlugin/PluginUI.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Numerics;
+﻿using System.Numerics;
 using System.Reflection;
 using System.Timers;
 using Dalamud.Logging;
 using H.Pipes.Args;
 using HypnotoadPlugin.Offsets;
 using ImGuiNET;
+using Timer = System.Timers.Timer;
 
 namespace HypnotoadPlugin;
 


### PR DESCRIPTION
Image Cleanup

* Since the image is no longer displayed in the settings UI, avoid loading the image.

Code Cleanup

* Redundant using directive
* Redundant 'Object.ToString()' call
* 'unsafe' context is redundant
* Redundant string interpolation
* Merge null/pattern checks into complex pattern
* Convert to file-scoped namespace
* Use preferred style for trailing comma before new line in multiline lists
* Member can be made static (shared)
* Parameter hides member
* Possible NPE
* Optimize Imports
* Auto-Indent Lines

Update Command Text

ImplicitUsings

* Make use of more modern latest C# & .net features.

Nullable & Cleanup

* Enabled nullable and project clean-up to follow .editorconfig code styling.

Some areas were intentionally left as-is  instead of the recommended IDE changes due to causing breakage when loading in-game.

* Renamed "Free Company" properly to match exact game name for internal backend name.